### PR TITLE
style: unify report month grid spacing

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -727,7 +727,7 @@ export default function App() {
 
                 {activeTab === 'relatorios' && (
                     <>
-                        <div className="meses-grid-container" style={{ gap: 'var(--spacing-sm)', marginBottom: 'var(--spacing-md)' }}>
+                        <div className="meses-grid-container relatorios-grid">
                             {MESES.map((nome, idx) => (
                                 <Button key={idx} size="sm" className={mesRelatorio === idx ? 'active' : ''} onClick={() => setMesRelatorio(idx)}>
                                     {nome.substring(0, 3).toUpperCase()}

--- a/src/index.css
+++ b/src/index.css
@@ -104,12 +104,12 @@ h2.text-center.text-primary {
 /* Grid de meses */
 .meses-grid-container {
   position: absolute;
-  top: 10px;
-  right: 10px;
+  top: var(--spacing-sm);
+  right: var(--spacing-sm);
   display: grid;
   grid-template-columns: repeat(4, 1fr);
   grid-template-rows: repeat(3, 1fr);
-  gap: 4px;
+  gap: var(--spacing-xs);
   width: 200px;
   border-radius: 8px;
   padding: 0;
@@ -751,4 +751,8 @@ h2.text-center.text-primary {
   .relatorio-row span {
     text-align: left;
   }
+}
+
+.relatorios-grid {
+  margin-bottom: var(--spacing-md);
 }


### PR DESCRIPTION
## Summary
- remove inline styles from reports month selector
- standardize month grid spacing with theme variables

## Testing
- `npm test -- --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68a4d94ee52c832c86e687bc6bb111a8