### PR TITLE
Anchor report month grid to container

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -726,10 +726,15 @@ export default function App() {
                 )}
 
                 {activeTab === 'relatorios' && (
-                    <>
+                    <div className="relatorios-container">
                         <div className="meses-grid-container relatorios-grid">
                             {MESES.map((nome, idx) => (
-                                <Button key={idx} size="sm" className={mesRelatorio === idx ? 'active' : ''} onClick={() => setMesRelatorio(idx)}>
+                                <Button
+                                    key={idx}
+                                    size="sm"
+                                    className={mesRelatorio === idx ? 'active' : ''}
+                                    onClick={() => setMesRelatorio(idx)}
+                                >
                                     {nome.substring(0, 3).toUpperCase()}
                                 </Button>
                             ))}
@@ -756,7 +761,7 @@ export default function App() {
                                 ))}
                             </div>
                         </Card>
-                    </>
+                    </div>
                 )}
             </div>
 

--- a/src/index.css
+++ b/src/index.css
@@ -116,6 +116,11 @@ h2.text-center.text-primary {
   z-index: 10;
 }
 
+/* Contêiner para relatórios, mantendo o grid de meses ancorado */
+.relatorios-container {
+  position: relative;
+}
+
 .meses-grid-container .btn {
     background-color: var(--tab-inactive-bg);
     color: var(--tab-inactive-text);


### PR DESCRIPTION
## Summary
- wrap reports section in `relatorios-container` with relative positioning so month grid stays anchored
- ensure month selector buttons use theme variables with no inline overrides

## Testing
- `npm test -- --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68a4dd288cd4832cb84399833ffdf51b