### PR TITLE
Add monthly totals summary for reports

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -66,6 +66,15 @@ export default function App() {
 
     const [mesRelatorio, setMesRelatorio] = useState(new Date().getMonth());
     const [relatorio, setRelatorio] = useState({});
+    const totaisRelatorio = useMemo(() => {
+        const dados = relatorio[mesRelatorio] || {};
+        return Object.values(dados).reduce((acc, setor) => ({
+            solicitadas: acc.solicitadas + (setor.solicitadas || 0),
+            andamento: acc.andamento + (setor.andamento || 0),
+            concluidas: acc.concluidas + (setor.concluidas || 0),
+            naoIniciadas: acc.naoIniciadas + (setor.naoIniciadas || 0)
+        }), { solicitadas: 0, andamento: 0, concluidas: 0, naoIniciadas: 0 });
+    }, [relatorio, mesRelatorio]);
 
     const isFormValid = useMemo(() => {
         const { tarefa, responsavel, repetir, prioridade, setor } = novaTarefa;
@@ -738,6 +747,25 @@ export default function App() {
                                     {nome.substring(0, 3).toUpperCase()}
                                 </Button>
                             ))}
+                        </div>
+
+                        <div className="relatorio-totais">
+                            <Card>
+                                <Title level={5}>Solicitadas</Title>
+                                <span>{totaisRelatorio.solicitadas}</span>
+                            </Card>
+                            <Card>
+                                <Title level={5}>Em Andamento</Title>
+                                <span>{totaisRelatorio.andamento}</span>
+                            </Card>
+                            <Card>
+                                <Title level={5}>Concluídas</Title>
+                                <span>{totaisRelatorio.concluidas}</span>
+                            </Card>
+                            <Card>
+                                <Title level={5}>Não Iniciadas</Title>
+                                <span>{totaisRelatorio.naoIniciadas}</span>
+                            </Card>
                         </div>
 
                         <Card>

--- a/src/index.css
+++ b/src/index.css
@@ -121,6 +121,12 @@ h2.text-center.text-primary {
   position: relative;
 }
 
+.relatorio-totais {
+  display: flex;
+  gap: var(--spacing-md);
+  margin-bottom: var(--spacing-md);
+}
+
 .meses-grid-container .btn {
     background-color: var(--tab-inactive-bg);
     color: var(--tab-inactive-text);


### PR DESCRIPTION
## Summary
- compute memoized totals for each report status
- show report status totals in new cards above sector summary
- style report totals container with themed spacing

## Testing
- `npm test` *(fails: No tests found, exiting with code 1)*

------
https://chatgpt.com/codex/tasks/task_e_68a4de617dd0832c9135f676da801b92