### PR TITLE
Sort sector summary alphabetically

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -750,7 +750,7 @@ export default function App() {
                                     <span>Concluídas</span>
                                     <span>Não Iniciadas</span>
                                 </div>
-                                {Object.entries(relatorio[mesRelatorio] || {}).map(([setor, dados]) => (
+                                {Object.entries(relatorio[mesRelatorio] || {}).sort(([a],[b]) => a.localeCompare(b)).map(([setor, dados]) => (
                                     <div key={setor} className="relatorio-row">
                                         <span>{setor}</span>
                                         <span>{dados.solicitadas}</span>


### PR DESCRIPTION
## Summary
- order sector summary table from A to Z using localeCompare

## Testing
- `npm test -- --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68a4de6ff000832c9eac957ae428ab48