### PR TITLE
Move Relatórios month selector to header

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -609,6 +609,21 @@ export default function App() {
                     </div>
                 )}
 
+                {activeTab === 'relatorios' && (
+                    <div className="meses-grid-container">
+                        {MESES.map((nome, idx) => (
+                            <Button
+                                key={idx}
+                                size="sm"
+                                className={mesRelatorio === idx ? 'active' : ''}
+                                onClick={() => setMesRelatorio(idx)}
+                            >
+                                {nome.substring(0, 3).toUpperCase()}
+                            </Button>
+                        ))}
+                    </div>
+                )}
+
 
 
 
@@ -736,19 +751,6 @@ export default function App() {
 
                 {activeTab === 'relatorios' && (
                     <div className="relatorios-container">
-                        <div className="meses-grid-container relatorios-grid">
-                            {MESES.map((nome, idx) => (
-                                <Button
-                                    key={idx}
-                                    size="sm"
-                                    className={mesRelatorio === idx ? 'active' : ''}
-                                    onClick={() => setMesRelatorio(idx)}
-                                >
-                                    {nome.substring(0, 3).toUpperCase()}
-                                </Button>
-                            ))}
-                        </div>
-
                         <div className="relatorio-totais">
                             <Card>
                                 <Title level={5}>Solicitadas</Title>


### PR DESCRIPTION
## Summary
- Add month selector to header for Relatórios tab
- Remove redundant month grid from Relatórios content area

## Testing
- `CI=true npm test -- --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68a4e1480634832c96a18e3e5c8dfa2c