### PR TITLE
chore: refine month grid button styling

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -127,7 +127,7 @@ h2.text-center.text-primary {
   margin-bottom: var(--spacing-md);
 }
 
-.meses-grid-container .btn {
+.meses-grid-container button {
     background-color: var(--tab-inactive-bg);
     color: var(--tab-inactive-text);
     border: 1px solid var(--tab-inactive-bg);
@@ -141,13 +141,13 @@ h2.text-center.text-primary {
     padding: 0 5px;
     border-radius: 4px;
   }
-  .meses-grid-container .btn:hover {
+  .meses-grid-container button:hover {
     background-color: var(--tab-inactive-bg);
     color: var(--tab-active-text);
   }
-  .meses-grid-container .btn.active,
-  .meses-grid-container .btn:focus,
-  .meses-grid-container .btn:active {
+  .meses-grid-container button.active,
+  .meses-grid-container button:focus,
+  .meses-grid-container button:active {
     background-color: var(--tab-active-bg);
     color: var(--tab-active-text);
     border-color: var(--tab-active-bg);


### PR DESCRIPTION
## Summary
- target month grid buttons directly to avoid Bootstrap overrides
- ensure tab color variables remain untouched

## Testing
- `npm test` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68a4e2a8d228832cba5c65928866b48b