### PR TITLE
Center relatorio cards in reports view

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -129,7 +129,10 @@ h2.text-center.text-primary {
 .relatorio-totais {
   display: flex;
   gap: var(--spacing-md);
-  margin-bottom: var(--spacing-md);
+  margin: 0 auto var(--spacing-md);
+  justify-content: center;
+  width: 100%;
+  max-width: 900px;
 }
 
 .meses-grid-container button {


### PR DESCRIPTION
## Summary
- center "relatorio-totais" card container and span full width with optional max-width

## Testing
- `npm test -- --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68a4ef3569b0832c934fd05b58bcf27d