### PR TITLE
Reduce report grid padding

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -745,7 +745,7 @@ h2.text-center.text-primary {
 
 .relatorio-header span,
 .relatorio-row span {
-  padding: var(--spacing-sm);
+  padding: calc(var(--spacing-sm) / 2);
   text-align: center;
 }
 


### PR DESCRIPTION
## Summary
- Halve padding on report header and rows using theme spacing variables

## Testing
- `npm test -- --passWithNoTests`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a4ef3bbb38832c97d6c6070c72838d