### PR TITLE
fix: remove redundant setor summary title

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -771,7 +771,6 @@ export default function App() {
                         </div>
 
                         <Card>
-                            <Title level={4}>Resumo por Setor</Title>
                             <div className="relatorio-grid">
                                 <div className="relatorio-header">
                                     <span>Setor</span>


### PR DESCRIPTION
## Summary
- remove unused "Resumo por Setor" title from reports tab

## Testing
- `npm test -- --passWithNoTests`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68a4f1e954e8832c8fad5694b4e96876