### PR TITLE
feat: improve report totals layout

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -752,6 +752,7 @@ export default function App() {
                 {activeTab === 'relatorios' && (
                     <div className="relatorios-container">
                         <div className="relatorio-totais">
+                            <div className="totais-placeholder" />
                             <Card>
                                 <Title level={5}>Solicitadas</Title>
                                 <span>{totaisRelatorio.solicitadas}</span>

--- a/src/index.css
+++ b/src/index.css
@@ -126,13 +126,27 @@ h2.text-center.text-primary {
   position: relative;
 }
 
+
 .relatorio-totais {
-  display: flex;
-  gap: var(--spacing-md);
-  margin: 0 auto var(--spacing-md);
-  justify-content: center;
-  width: 100%;
+  display: grid;
+  grid-template-columns: 1fr repeat(4, minmax(calc(var(--spacing-md) * 8), 1fr));
+  gap: var(--spacing-xs);
   max-width: 900px;
+  margin: 0 auto var(--spacing-md);
+}
+
+.totais-placeholder {
+  visibility: hidden;
+}
+
+.relatorio-totais .card {
+  background-color: var(--tab-inactive-bg);
+  color: var(--tab-inactive-text);
+  text-align: center;
+}
+
+.relatorio-totais .card span {
+  color: var(--tab-inactive-text);
 }
 
 .meses-grid-container button {


### PR DESCRIPTION
## Summary
- add placeholder to report totals to reserve sector column
- switch report totals to themed grid layout with green card styling

## Testing
- `npm test -- --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68a4f4781c0c832cb1e401a91ea8077f