### PR TITLE
Reduz espaçamento da grade de relatórios

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -737,7 +737,7 @@ h2.text-center.text-primary {
 .relatorio-grid {
   display: grid;
   grid-template-columns: repeat(5, 1fr);
-  gap: var(--spacing-sm);
+  gap: var(--spacing-xs);
   color: var(--text-primary);
 }
 
@@ -748,7 +748,7 @@ h2.text-center.text-primary {
 
 .relatorio-header span,
 .relatorio-row span {
-  padding: calc(var(--spacing-sm) / 2);
+  padding: var(--spacing-xs);
   text-align: center;
 }
 


### PR DESCRIPTION
## Resumo
- reduz espaçamento entre colunas da grade de relatórios
- simplifica padding das células usando variáveis do tema

## Testes
- `npm test -- --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_68a4f6c00680832cb5c78b52b71c274c