### PR TITLE
Remover cabeçalho da grade de relatório

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -772,13 +772,6 @@ export default function App() {
 
                         <Card>
                             <div className="relatorio-grid">
-                                <div className="relatorio-header">
-                                    <span>Setor</span>
-                                    <span>Solicitadas</span>
-                                    <span>Em Andamento</span>
-                                    <span>Concluídas</span>
-                                    <span>Não Iniciadas</span>
-                                </div>
                                 {Object.entries(relatorio[mesRelatorio] || {}).sort(([a],[b]) => a.localeCompare(b)).map(([setor, dados]) => (
                                     <div key={setor} className="relatorio-row">
                                         <span>{setor}</span>


### PR DESCRIPTION
## Summary
- remover cabeçalho de títulos da grade de relatórios para que apenas linhas de dados de setores sejam renderizadas

## Testing
- `npm test -- --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68a5c0687740832cb825df3f4857e6d8