### PR TITLE
Align relatório totais with grid layout

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -752,6 +752,7 @@ export default function App() {
                 {activeTab === 'relatorios' && (
                     <div className="relatorios-container">
                         <div className="relatorio-totais">
+                            <div className="totais-placeholder" />
                             <Card>
                                 <Title level={5}>Solicitadas</Title>
                                 <span>{totaisRelatorio.solicitadas}</span>

--- a/src/index.css
+++ b/src/index.css
@@ -127,12 +127,27 @@ h2.text-center.text-primary {
 }
 
 .relatorio-totais {
-  display: flex;
-  gap: var(--spacing-md);
-  margin: 0 auto var(--spacing-md);
+  display: grid;
+  grid-template-columns: 1fr repeat(4, calc(var(--spacing-md) * 8));
+  gap: var(--spacing-sm);
   justify-content: center;
-  width: 100%;
-  max-width: 900px;
+  margin-bottom: var(--spacing-md);
+}
+
+.totais-placeholder {
+  visibility: hidden;
+}
+
+.relatorio-totais .card {
+  width: calc(var(--spacing-md) * 8);
+  height: calc(var(--spacing-md) * 6);
+  background-color: var(--tab-inactive-bg);
+  color: var(--tab-inactive-text);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
 }
 
 .meses-grid-container button {


### PR DESCRIPTION
## Summary
- add placeholder div for setores alignment in relatório totals
- style relatório total cards with grid, fixed size, and theme colors

## Testing
- `npm test` *(fails: No tests found, exiting with code 1)*

------
https://chatgpt.com/codex/tasks/task_e_68a5c06d8990832ca5735adb7af704d1