### PR TITLE
Implement grid layout for report totals

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -749,9 +749,10 @@ export default function App() {
                     </div>
                 )}
 
-                {activeTab === 'relatorios' && (
+                    {activeTab === 'relatorios' && (
                     <div className="relatorios-container">
                         <div className="relatorio-totais">
+                            <div className="totais-placeholder" />
                             <Card>
                                 <Title level={5}>Solicitadas</Title>
                                 <span>{totaisRelatorio.solicitadas}</span>

--- a/src/index.css
+++ b/src/index.css
@@ -127,12 +127,14 @@ h2.text-center.text-primary {
 }
 
 .relatorio-totais {
-  display: flex;
-  gap: var(--spacing-md);
-  margin: 0 auto var(--spacing-md);
+  display: grid;
+  grid-template-columns: 1fr repeat(4, 1fr);
+  gap: var(--spacing-sm);
   justify-content: center;
-  width: 100%;
-  max-width: 900px;
+  margin: 0 auto var(--spacing-md);
+}
+.totais-placeholder {
+  visibility: hidden;
 }
 
 .meses-grid-container button {


### PR DESCRIPTION
## Summary
- Add placeholder column to align report totals with sector grid
- Convert report totals container to CSS grid using theme spacing

## Testing
- `npm test -- --passWithNoTests`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a5c26e3210832c91edb9bf586ec704