### PR TITLE
Align report totals to grid columns

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -8,6 +8,7 @@
   --spacing-xs: 4px;
   --spacing-sm: 8px;
   --spacing-md: 16px;
+  --relatorio-col-width: calc(var(--spacing-md) * 5);
 }
 
 html, body, #root {
@@ -128,13 +129,22 @@ h2.text-center.text-primary {
 
 .relatorio-totais {
   display: grid;
-  grid-template-columns: 1fr repeat(4, 1fr);
-  gap: var(--spacing-sm);
+  grid-template-columns: 1fr repeat(4, var(--relatorio-col-width));
   justify-content: center;
+  gap: var(--spacing-xs);
   margin: 0 auto var(--spacing-md);
 }
 .totais-placeholder {
   visibility: hidden;
+}
+
+.relatorio-totais .card {
+  width: var(--relatorio-col-width);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
 }
 
 .meses-grid-container button {


### PR DESCRIPTION
## Summary
- add CSS variable for report column width
- align report total cards to table grid columns

## Testing
- `npm test -- --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68a5c4721494832c98f294f452d8738a