### PR TITLE
Remove YAxis labels in bar chart

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -789,7 +789,7 @@ export default function App() {
                             <ResponsiveContainer width="100%" height="100%">
                                 <BarChart data={dadosSolicitadas}>
                                     <XAxis dataKey="setor" stroke="var(--text-primary)" />
-                                    <YAxis stroke="var(--text-primary)" />
+                                    <YAxis tick={false} axisLine={false} />
                                     <Tooltip />
                                     <Bar dataKey="solicitadas" fill="var(--tab-inactive-bg)" />
                                 </BarChart>


### PR DESCRIPTION
## Summary
- hide vertical axis labels in `BarChart`

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a5d3a106e0832cb2248223552e3a0f