### PR TITLE
Fix report chart layout to use full width

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -787,9 +787,9 @@ export default function App() {
                         </Card>
                         <div className="relatorio-chart">
                             <ResponsiveContainer width="100%" height="100%">
-                                <BarChart data={dadosSolicitadas}>
+                                <BarChart data={dadosSolicitadas} margin={{ left: 0 }}>
                                     <XAxis dataKey="setor" stroke="var(--text-primary)" />
-                                    <YAxis tick={false} axisLine={false} />
+                                    <YAxis width={0} tick={false} axisLine={false} />
                                     <Tooltip />
                                     <Bar dataKey="solicitadas" fill="var(--tab-inactive-bg)" />
                                 </BarChart>


### PR DESCRIPTION
## Summary
- ensure bar chart fills horizontal space by removing YAxis width and left margin

## Testing
- `npm test` (fails: react-scripts not found)
- `npm install --no-audit --no-fund` (fails: 403 Forbidden fetching dependencies)


------
https://chatgpt.com/codex/tasks/task_e_68a5d99e714c832ca1af171a9d9cbf88