### PR TITLE
feat: add page background theme variable

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -4,6 +4,8 @@
   --tab-active-bg: #FFFF99;
   --tab-active-text: #C00000;
 
+  --page-bg: #c6e0b4;
+
   /* Spacing scale */
   --spacing-xs: 4px;
   --spacing-sm: 8px;
@@ -13,7 +15,7 @@
 html, body, #root {
   height: 100%;
   margin: 0;
-  background-color: #c6e0b4; /* Fundo do Mural */
+  background-color: var(--page-bg); /* Fundo do Mural */
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
     'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue', sans-serif;
   overflow-y: auto;
@@ -23,7 +25,7 @@ html, body, #root {
   display: flex;
   flex-direction: column;
   flex: 1;
-  background-color: #c6e0b4 !important; /* Fundo do Mural */
+  background-color: var(--page-bg) !important; /* Fundo do Mural */
   padding: 0;
   margin: 0;
   position: relative;
@@ -787,5 +789,5 @@ h2.text-center.text-primary {
   width: 100%;
   height: calc(var(--spacing-md) * 20);
   margin-top: var(--spacing-md);
-  background-color: var(--tab-inactive-text);
+  background-color: var(--page-bg);
 }


### PR DESCRIPTION
## Summary
- add `--page-bg` theme variable for global page background
- use `--page-bg` for page and report chart backgrounds

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a5db2182f8832c9487775bbd1ca23a