### PR TITLE
feat: add alternating report row backgrounds

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -5,6 +5,8 @@
   --tab-active-text: #C00000;
 
   --page-bg: #c6e0b4;
+  --relatorio-row-bg: var(--page-bg);
+  --relatorio-row-bg-alt: color-mix(in srgb, var(--tab-inactive-bg) 20%, var(--page-bg));
 
   /* Spacing scale */
   --spacing-xs: 4px;
@@ -754,6 +756,13 @@ h2.text-center.text-primary {
 .relatorio-row span {
   padding: calc(var(--spacing-sm) / 2);
   text-align: center;
+}
+
+.relatorio-row:nth-of-type(odd) span {
+  background-color: var(--relatorio-row-bg);
+}
+.relatorio-row:nth-of-type(even) span {
+  background-color: var(--relatorio-row-bg-alt);
 }
 
 .relatorio-header span {


### PR DESCRIPTION
## Summary
- define new report row background variables based on existing theme colors
- alternate report row span backgrounds to improve readability

## Testing
- `npm test` *(fails: react-scripts: not found; dependencies may be missing)*

------
https://chatgpt.com/codex/tasks/task_e_68a5e0a31228832c9c1e523b506439fa