### PR TITLE
Add extra-small spacing and apply to chart bars

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -578,6 +578,12 @@ export default function App() {
         );
     };
 
+    const getSpacing = name =>
+        parseInt(
+            getComputedStyle(document.documentElement).getPropertyValue(`--spacing-${name}`),
+            10
+        );
+
     return (
         <Container fluid className="mt-3 d-flex flex-column" style={{ minHeight: '100vh' }}>
             {mensagem && (
@@ -806,7 +812,12 @@ export default function App() {
                                     />
                                     <YAxis width={0} tick={false} axisLine={false} />
                                     <Tooltip />
-                                    <Bar dataKey="solicitadas" fill="var(--tab-inactive-bg)" />
+                                    <Bar
+                                        dataKey="solicitadas"
+                                        fill="var(--tab-inactive-bg)"
+                                        barSize={getSpacing('xxs')}
+                                        radius={[getSpacing('xxs'), getSpacing('xxs'), 0, 0]}
+                                    />
                                 </BarChart>
                             </ResponsiveContainer>
                         </div>

--- a/src/index.css
+++ b/src/index.css
@@ -9,6 +9,7 @@
   --relatorio-row-bg-alt: color-mix(in srgb, var(--tab-inactive-bg) 20%, var(--page-bg));
 
   /* Spacing scale */
+  --spacing-xxs: 2px;
   --spacing-xs: 4px;
   --spacing-sm: 8px;
   --spacing-md: 16px;


### PR DESCRIPTION
## Summary
- extend spacing scale with `--spacing-xxs`
- size and round report bars using theme spacing values

## Testing
- `npm test` (fails: react-scripts not found)
- `npm install --no-audit --no-fund` (fails: 403 Forbidden for registry)


------
https://chatgpt.com/codex/tasks/task_e_68a5f016ec00832cb50309cce5c443f1