### PR TITLE
feat: add themed drop shadow for chart bars

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -806,6 +806,11 @@ h2.text-center.text-primary {
   background-color: var(--page-bg);
 }
 
+.relatorio-chart .recharts-bar-rectangle path {
+  filter: drop-shadow(var(--spacing-xs) 0 color-mix(in srgb,
+    var(--tab-inactive-bg) 40%, transparent));
+}
+
 .relatorio-chart .recharts-cartesian-axis-tick text {
   font-size: var(--font-size-sm);
 }


### PR DESCRIPTION
## Summary
- add theme-based drop shadow to relatorio chart bars for subtle right-side highlight

## Testing
- `npm test` *(fails: react-scripts not found after dependency install 403)*

------
https://chatgpt.com/codex/tasks/task_e_68a5f017f8f8832c8a9e8edd776a5dbc