### PR TITLE
Ajusta espaçamento do gráfico de relatórios

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -578,6 +578,13 @@ export default function App() {
         );
     };
 
+    const getSpacing = name =>
+      parseInt(
+        getComputedStyle(document.documentElement)
+          .getPropertyValue(`--spacing-${name}`),
+        10
+      );
+
     return (
         <Container fluid className="mt-3 d-flex flex-column" style={{ minHeight: '100vh' }}>
             {mensagem && (
@@ -798,10 +805,12 @@ export default function App() {
                         </Card>
                         <div className="relatorio-chart">
                             <ResponsiveContainer width="100%" height="100%">
-                                <BarChart data={dadosSolicitadas} margin={{ left: 0 }}>
+                                <BarChart data={dadosSolicitadas} margin={{ left: 0, bottom: getSpacing('sm') }}>
                                     <XAxis
                                         dataKey="setor"
                                         tick={<SetorTick />}
+                                        height={getSpacing('md')}
+                                        tickMargin={getSpacing('xs')}
                                         interval={0}
                                     />
                                     <YAxis width={0} tick={false} axisLine={false} />


### PR DESCRIPTION
## Summary
- adiciona helper getSpacing para acessar espaçamentos do tema
- aplica espaçamentos temáticos ao BarChart e ao XAxis do relatório

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a635632fd8832cac32c62b0c6a9ba1