### PR TITLE
Center chart tick text vertically

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -568,7 +568,7 @@ export default function App() {
     };
 
     const SetorTick = ({ x, y, payload }) => (
-        <text x={x} y={y} fill="var(--text-primary)" textAnchor="middle">
+        <text x={x} y={y} fill="var(--text-primary)" textAnchor="middle" dominantBaseline="middle">
             {payload.value}
         </text>
     );


### PR DESCRIPTION
## Summary
- ensure Setor chart tick labels are vertically centered

## Testing
- `npm test` *(fails: react-scripts not found)*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/recharts)*

------
https://chatgpt.com/codex/tasks/task_e_68a76f8f0b8c832c9766dfaba1c9aae4