### PR TITLE
chore: adjust sector tick spacing

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -568,7 +568,13 @@ export default function App() {
     };
 
     const SetorTick = ({ x, y, payload }) => (
-        <text x={x} y={y} fill="var(--text-primary)" textAnchor="middle">
+        <text
+            x={x}
+            y={y}
+            dy="var(--spacing-sm)"
+            fill="var(--text-primary)"
+            textAnchor="middle"
+        >
             {payload.value}
         </text>
     );


### PR DESCRIPTION
## Summary
- add themed vertical offset to `SetorTick`

## Testing
- `npm test` *(fails: react-scripts not found)*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/recharts)*

------
https://chatgpt.com/codex/tasks/task_e_68a7714bf000832cbd3881e0e83025c4