### PR TITLE
feat: restore card styling for task forms

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -731,29 +731,33 @@ export default function App() {
                 )}
 
                 {activeTab === 'tarefas' && (
-                    <div style={{ height: '14.8cm', width: '100%' }} className="ag-theme-alpine">
-                        <TarefaGrid
-                            dados={tarefas}
-                            tipo="tarefas"
-                            onReabrir={reabrir}
-                            onMoverParaAndamento={moverParaAndamento}
-                            carregando={carregando}
-                        />
-                    </div>
+                    <Card>
+                        <div style={{ height: '14.8cm', width: '100%' }} className="ag-theme-alpine">
+                            <TarefaGrid
+                                dados={tarefas}
+                                tipo="tarefas"
+                                onReabrir={reabrir}
+                                onMoverParaAndamento={moverParaAndamento}
+                                carregando={carregando}
+                            />
+                        </div>
+                    </Card>
                 )}
 
                 {activeTab === 'em_andamento' && (
-                    <div style={{ height: '14.8cm', width: '100%' }} className="ag-theme-alpine">
-                        <TarefaGrid
-                            dados={emAndamento}
-                            tipo="em_andamento"
-                            onConcluir={concluir}
-                            onReabrir={reabrir}
-                            carregando={carregando}
-                            onEditObservationClick={handleEditObservationClick}
-                            forceUpdate={forceUpdate}
-                        />
-                    </div>
+                    <Card>
+                        <div style={{ height: '14.8cm', width: '100%' }} className="ag-theme-alpine">
+                            <TarefaGrid
+                                dados={emAndamento}
+                                tipo="em_andamento"
+                                onConcluir={concluir}
+                                onReabrir={reabrir}
+                                carregando={carregando}
+                                onEditObservationClick={handleEditObservationClick}
+                                forceUpdate={forceUpdate}
+                            />
+                        </div>
+                    </Card>
                 )}
 
                 {activeTab === 'concluidas' && (
@@ -815,7 +819,8 @@ export default function App() {
                     <Modal.Title>{editId ? 'Editar' : 'Nova'} Tarefa</Modal.Title>
                 </Modal.Header>
                 <Modal.Body>
-                    <Form>
+                    <Card>
+                        <Form>
                         <FormGroup className="mb-2">
                             <label>Tarefa *</label>
                             <Input
@@ -889,7 +894,8 @@ export default function App() {
                                 </FormGroup>
                             </Col>
                         </Row>
-                    </Form>
+                        </Form>
+                    </Card>
                 </Modal.Body>
                 <Modal.Footer>
                     <Button variant="secondary" onClick={() => setShowModal(false)}>Cancelar</Button>

--- a/src/index.css
+++ b/src/index.css
@@ -16,14 +16,21 @@
   --relatorio-row-height: calc(var(--spacing-md) * 2);
 }
 
-html, body, #root {
-  height: 100%;
-  margin: 0;
-  background-color: var(--page-bg); /* Fundo do Mural */
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
-    'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue', sans-serif;
-  overflow-y: auto;
-}
+  html, body, #root {
+    height: 100%;
+    margin: 0;
+    background-color: var(--page-bg); /* Fundo do Mural */
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
+      'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue', sans-serif;
+    overflow-y: auto;
+  }
+
+  .card {
+    background-color: var(--page-bg);
+    padding: var(--spacing-md);
+    border-radius: var(--spacing-sm);
+    box-shadow: var(--shadow-md);
+  }
 
 .container-fluid {
   display: flex;

--- a/src/styles/index.js
+++ b/src/styles/index.js
@@ -1,7 +1,11 @@
 import React from 'react';
 
 export const Button = ({ children, ...props }) => <button {...props}>{children}</button>;
-export const Card = ({ children, ...props }) => <div {...props}>{children}</div>;
+export const Card = ({ children, className = '', ...props }) => (
+  <div className={['card', className].filter(Boolean).join(' ')} {...props}>
+    {children}
+  </div>
+);
 export const Input = ({ as = 'input', ...props }) => {
   const Component = as === 'textarea' ? 'textarea' : as === 'select' ? 'select' : 'input';
   return <Component {...props} />;


### PR DESCRIPTION
## Summary
- ensure Card component automatically applies `card` class
- add themed `.card` styles
- wrap task creation and editing flows with Card for consistent layout

## Testing
- `npm test` *(fails: react-scripts not found)*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/recharts)*

------
https://chatgpt.com/codex/tasks/task_e_68a777b62424832c85d38327038caf88