### PR TITLE
feat: unify card styling and theme overlays

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,7 +1,7 @@
 // src/App.js
 import React, { useState, useEffect, useMemo } from 'react';
 import { createClient } from '@supabase/supabase-js';
-import { Container, Tabs, Tab, Modal, Row, Col, Alert } from 'react-bootstrap';
+import { Container, Tabs, Tab, Row, Col, Alert } from 'react-bootstrap';
 import { Button, Card, Input, Title, Form, FormGroup } from './styles';
 import { TabbedOverlay, useTabbedOverlay } from './styles/components/overlays';
 import TarefaGrid from './components/TarefaGrid';
@@ -809,13 +809,11 @@ export default function App() {
                 )}
             </div>
 
-            {/* Modal ORIGINAL (para Criar/Editar Tarefa) */}
-            <Modal show={showModal} onHide={() => setShowModal(false)}>
-                <Modal.Header closeButton>
-                    <Modal.Title>{editId ? 'Editar' : 'Nova'} Tarefa</Modal.Title>
-                </Modal.Header>
-                <Modal.Body>
-                    <Form>
+            {/* Overlay para Criar/Editar Tarefa */}
+            <TabbedOverlay isOpen={showModal}>
+                <Card>
+                <Title level={3}>{editId ? 'Editar' : 'Nova'} Tarefa</Title>
+                <Form>
                         <FormGroup className="mb-2">
                             <label>Tarefa *</label>
                             <Input
@@ -890,12 +888,12 @@ export default function App() {
                             </Col>
                         </Row>
                     </Form>
-                </Modal.Body>
-                <Modal.Footer>
-                    <Button variant="secondary" onClick={() => setShowModal(false)}>Cancelar</Button>
-                    <Button variant="primary" onClick={salvarTarefa} disabled={!isFormValid}>Salvar</Button>
-                </Modal.Footer>
-            </Modal>
+                <div className="overlay-actions">
+                    <Button onClick={() => setShowModal(false)}>Cancelar</Button>
+                    <Button onClick={salvarTarefa} disabled={!isFormValid}>Salvar</Button>
+                </div>
+                </Card>
+            </TabbedOverlay>
 
             {/* Modal de Descrição da Tarefa (apenas para exibição) */}
             {showDescriptionModal && (
@@ -925,12 +923,10 @@ export default function App() {
                 </div>
             )}
 
-            {/* NOVO MODAL PARA EDIÇÃO DE OBSERVAÇÕES */}
-            <Modal show={showEditObsModal} onHide={handleCloseEditObsModal}>
-                <Modal.Header closeButton>
-                    <Modal.Title>Editar Observação da Tarefa #{editingObsId}</Modal.Title>
-                </Modal.Header>
-                <Modal.Body>
+            {/* Overlay para edição de observações */}
+            <TabbedOverlay isOpen={showEditObsModal}>
+                <Card>
+                <Title level={3}>Editar Observação da Tarefa #{editingObsId}</Title>
                     <FormGroup className="mb-3">
                         <label>Observações</label>
                         <Input
@@ -941,16 +937,16 @@ export default function App() {
                             placeholder="Digite suas observações aqui..."
                         />
                     </FormGroup>
-                </Modal.Body>
-                <Modal.Footer>
-                    <Button variant="secondary" onClick={handleCloseEditObsModal}>
+                <div className="overlay-actions">
+                    <Button onClick={handleCloseEditObsModal}>
                         Cancelar
                     </Button>
-                    <Button variant="primary" onClick={handleSaveObservation}>
+                    <Button onClick={handleSaveObservation}>
                         Salvar Observação
                     </Button>
-                </Modal.Footer>
-            </Modal>
+                </div>
+                </Card>
+            </TabbedOverlay>
         </Container>
     );
 }

--- a/src/index.css
+++ b/src/index.css
@@ -14,6 +14,23 @@
   --spacing-md: 16px;
 
   --relatorio-row-height: calc(var(--spacing-md) * 2);
+
+  --surface-bg: #ffffff;
+  --shadow-md: 0 4px 6px rgba(0, 0, 0, 0.1);
+}
+
+.card {
+  background-color: var(--surface-bg);
+  padding: var(--spacing-md);
+  border-radius: var(--spacing-sm);
+  box-shadow: var(--shadow-md);
+}
+
+.overlay-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: var(--spacing-sm);
+  margin-top: var(--spacing-md);
 }
 
 html, body, #root {

--- a/src/styles/index.js
+++ b/src/styles/index.js
@@ -1,7 +1,11 @@
 import React from 'react';
 
 export const Button = ({ children, ...props }) => <button {...props}>{children}</button>;
-export const Card = ({ children, ...props }) => <div {...props}>{children}</div>;
+export const Card = ({ children, className = '', ...props }) => (
+  <div className={["card", className].filter(Boolean).join(" ")} {...props}>
+    {children}
+  </div>
+);
 export const Input = ({ as = 'input', ...props }) => {
   const Component = as === 'textarea' ? 'textarea' : as === 'select' ? 'select' : 'input';
   return <Component {...props} />;


### PR DESCRIPTION
## Summary
- ensure Card component always applies base `card` class
- add theme variables and `.card` styling
- migrate task overlays to use themed `Card`

## Testing
- `npm test` *(fails: react-scripts not found)*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/recharts)*

------
https://chatgpt.com/codex/tasks/task_e_68a77af453e4832cba23a64b3a0ac88f