### PR TITLE
feat: apply card styling to task forms

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -815,81 +815,83 @@ export default function App() {
                     <Modal.Title>{editId ? 'Editar' : 'Nova'} Tarefa</Modal.Title>
                 </Modal.Header>
                 <Modal.Body>
-                    <Form>
-                        <FormGroup className="mb-2">
-                            <label>Tarefa *</label>
-                            <Input
-                                name="tarefa"
-                                value={novaTarefa.tarefa}
-                                onChange={e => setNovaTarefa({ ...novaTarefa, [e.target.name]: e.target.value })}
-                            />
-                        </FormGroup>
-                        <FormGroup className="mb-2">
-                            <label>Descrição</label>
-                            <Input
-                                name="descricao"
-                                value={novaTarefa.descricao}
-                                onChange={e => setNovaTarefa({ ...novaTarefa, [e.target.name]: e.target.value })}
-                            />
-                        </FormGroup>
-                        <Row>
-                            <Col>
-                                <FormGroup className="mb-2">
-                                    <label>Responsável *</label>
-                                    <Input
-                                        as="select"
-                                        name="responsavel"
-                                        value={novaTarefa.responsavel}
-                                        onChange={e => setNovaTarefa({ ...novaTarefa, [e.target.name]: e.target.value })}
-                                    >
-                                        <option>JEAN</option>
-                                        <option>IVANA</option>
-                                    </Input>
-                                </FormGroup>
-                            </Col>
-                            <Col>
-                                <FormGroup className="mb-2">
-                                    <label>Repetir *</label>
-                                    <Input
-                                        as="select"
-                                        name="repetir"
-                                        value={novaTarefa.repetir}
-                                        onChange={e => setNovaTarefa({ ...novaTarefa, [e.target.name]: e.target.value })}
-                                    >
-                                        <option>SIM</option>
-                                        <option>NÃO</option>
-                                    </Input>
-                                </FormGroup>
-                            </Col>
-                        </Row>
-                        <Row>
-                            <Col>
-                                <FormGroup className="mb-2">
-                                    <label>Prioridade *</label>
-                                    <Input
-                                        as="select"
-                                        name="prioridade"
-                                        value={novaTarefa.prioridade}
-                                        onChange={e => setNovaTarefa({ ...novaTarefa, [e.target.name]: e.target.value })}
-                                    >
-                                        <option>BAIXA</option>
-                                        <option>NORMAL</option>
-                                        <option>ALTA</option>
-                                    </Input>
-                                </FormGroup>
-                            </Col>
-                            <Col>
-                                <FormGroup className="mb-2">
-                                    <label>Setor *</label>
-                                    <Input
-                                        name="setor"
-                                        value={novaTarefa.setor}
-                                        onChange={e => setNovaTarefa({ ...novaTarefa, [e.target.name]: e.target.value })}
-                                    />
-                                </FormGroup>
-                            </Col>
-                        </Row>
-                    </Form>
+                    <Card>
+                        <Form>
+                            <FormGroup className="mb-2">
+                                <label>Tarefa *</label>
+                                <Input
+                                    name="tarefa"
+                                    value={novaTarefa.tarefa}
+                                    onChange={e => setNovaTarefa({ ...novaTarefa, [e.target.name]: e.target.value })}
+                                />
+                            </FormGroup>
+                            <FormGroup className="mb-2">
+                                <label>Descrição</label>
+                                <Input
+                                    name="descricao"
+                                    value={novaTarefa.descricao}
+                                    onChange={e => setNovaTarefa({ ...novaTarefa, [e.target.name]: e.target.value })}
+                                />
+                            </FormGroup>
+                            <Row>
+                                <Col>
+                                    <FormGroup className="mb-2">
+                                        <label>Responsável *</label>
+                                        <Input
+                                            as="select"
+                                            name="responsavel"
+                                            value={novaTarefa.responsavel}
+                                            onChange={e => setNovaTarefa({ ...novaTarefa, [e.target.name]: e.target.value })}
+                                        >
+                                            <option>JEAN</option>
+                                            <option>IVANA</option>
+                                        </Input>
+                                    </FormGroup>
+                                </Col>
+                                <Col>
+                                    <FormGroup className="mb-2">
+                                        <label>Repetir *</label>
+                                        <Input
+                                            as="select"
+                                            name="repetir"
+                                            value={novaTarefa.repetir}
+                                            onChange={e => setNovaTarefa({ ...novaTarefa, [e.target.name]: e.target.value })}
+                                        >
+                                            <option>SIM</option>
+                                            <option>NÃO</option>
+                                        </Input>
+                                    </FormGroup>
+                                </Col>
+                            </Row>
+                            <Row>
+                                <Col>
+                                    <FormGroup className="mb-2">
+                                        <label>Prioridade *</label>
+                                        <Input
+                                            as="select"
+                                            name="prioridade"
+                                            value={novaTarefa.prioridade}
+                                            onChange={e => setNovaTarefa({ ...novaTarefa, [e.target.name]: e.target.value })}
+                                        >
+                                            <option>BAIXA</option>
+                                            <option>NORMAL</option>
+                                            <option>ALTA</option>
+                                        </Input>
+                                    </FormGroup>
+                                </Col>
+                                <Col>
+                                    <FormGroup className="mb-2">
+                                        <label>Setor *</label>
+                                        <Input
+                                            name="setor"
+                                            value={novaTarefa.setor}
+                                            onChange={e => setNovaTarefa({ ...novaTarefa, [e.target.name]: e.target.value })}
+                                        />
+                                    </FormGroup>
+                                </Col>
+                            </Row>
+                        </Form>
+                    </Card>
                 </Modal.Body>
                 <Modal.Footer>
                     <Button variant="secondary" onClick={() => setShowModal(false)}>Cancelar</Button>

--- a/src/index.css
+++ b/src/index.css
@@ -12,6 +12,7 @@
   --spacing-xs: 4px;
   --spacing-sm: 8px;
   --spacing-md: 16px;
+  --shadow-md: 0 4px 8px rgba(0, 0, 0, 0.15);
 
   --relatorio-row-height: calc(var(--spacing-md) * 2);
 }
@@ -33,6 +34,13 @@ html, body, #root {
   padding: 0;
   margin: 0;
   position: relative;
+}
+
+.card {
+  background-color: var(--page-bg);
+  padding: var(--spacing-md);
+  border-radius: var(--spacing-sm);
+  box-shadow: var(--shadow-md);
 }
 
 .header-content-container {

--- a/src/styles/index.js
+++ b/src/styles/index.js
@@ -1,7 +1,11 @@
 import React from 'react';
 
 export const Button = ({ children, ...props }) => <button {...props}>{children}</button>;
-export const Card = ({ children, ...props }) => <div {...props}>{children}</div>;
+export const Card = ({ children, className = '', ...props }) => (
+  <div className={["card", className].filter(Boolean).join(' ')} {...props}>
+    {children}
+  </div>
+);
 export const Input = ({ as = 'input', ...props }) => {
   const Component = as === 'textarea' ? 'textarea' : as === 'select' ? 'select' : 'input';
   return <Component {...props} />;


### PR DESCRIPTION
## Summary
- add default `card` class to Card component
- style `.card` with theme variables
- wrap task form modals with Card for consistent theming

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/recharts)*
- `npm test` *(fails: react-scripts: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a77f2e3b9c832c89f25b37274b70d6