### PR TITLE
feat: enhance TabbedOverlay with Card-based overlay

### DIFF
--- a/src/styles/components/overlays/index.js
+++ b/src/styles/components/overlays/index.js
@@ -1,6 +1,35 @@
 import React from 'react';
+import { Card } from '../..';
 
-export const TabbedOverlay = ({ isOpen, children }) => (isOpen ? <div>{children}</div> : null);
+const TabbedOverlay = ({ isOpen, children }) => (
+  isOpen ? (
+    <Card
+      style={{
+        position: 'fixed',
+        top: 0,
+        left: 0,
+        width: '100%',
+        height: '100%',
+        background: 'var(--overlay-bg)',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center'
+      }}
+    >
+      <Card
+        style={{
+          padding: 'var(--spacing-lg)',
+          background: 'var(--background)'
+        }}
+      >
+        {children}
+      </Card>
+    </Card>
+  ) : null
+);
+
+TabbedOverlay.Header = ({ children, ...props }) => <div {...props}>{children}</div>;
+TabbedOverlay.Footer = ({ children, ...props }) => <div {...props}>{children}</div>;
 
 export const useTabbedOverlay = () => {
   const [isOpen, setIsOpen] = React.useState(false);
@@ -10,3 +39,5 @@ export const useTabbedOverlay = () => {
     close: () => setIsOpen(false)
   };
 };
+
+export { TabbedOverlay };


### PR DESCRIPTION
## Summary
- Wrap TabbedOverlay content with a full-screen Card overlay using theme variables
- Add TabbedOverlay.Header and TabbedOverlay.Footer subcomponents

## Testing
- `npm test` *(fails: react-scripts not found)*
- `npm install` *(fails: 403 Forbidden - recharts)*

------
https://chatgpt.com/codex/tasks/task_e_68a789272d94832ca56dba8c37897f23