### PR TITLE
style: add border to tabbed overlay card

### DIFF
--- a/src/styles/components/overlays/TabbedOverlay.module.css
+++ b/src/styles/components/overlays/TabbedOverlay.module.css
@@ -1,0 +1,5 @@
+.card {
+  padding: var(--spacing-md);
+  border: var(--border-width) solid var(--primary);
+  border-radius: var(--border-radius);
+}


### PR DESCRIPTION
## Summary
- style TabbedOverlay card with theme borders and radius

## Testing
- `CI=true npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ac79845ee8832ca8754cd6c76e4f4b