### PR TITLE
style: add themed border to tabbed overlay card

### DIFF
--- a/src/styles/components/overlays/TabbedOverlay.module.css
+++ b/src/styles/components/overlays/TabbedOverlay.module.css
@@ -1,0 +1,5 @@
+.card {
+  border: var(--border-width) solid var(--primary);
+  border-radius: var(--border-radius);
+  padding: var(--spacing-md);
+}


### PR DESCRIPTION
## Summary
- add bordered, rounded styling to tabbed overlay card

## Testing
- `npm test` *(fails: react-scripts not found)*
- `npm install` *(fails: 403 Forbidden retrieving recharts)*

------
https://chatgpt.com/codex/tasks/task_e_68ac91fe62d8832c95c1e822f959bab8