### PR TITLE
refactor: replace bootstrap spacing with theme utilities

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -4,6 +4,7 @@ import { createClient } from '@supabase/supabase-js';
 import { Container, Tabs, Tab, Modal, Row, Col, Alert } from 'react-bootstrap';
 import { Button, Card, Input, Title, Form, FormGroup } from './styles';
 import { TabbedOverlay, useTabbedOverlay } from './styles/components/overlays';
+import styles from './styles/index.module.css';
 import TarefaGrid from './components/TarefaGrid';
 import { ResponsiveContainer, BarChart, Bar, XAxis, YAxis, Tooltip } from 'recharts';
 // Certifique-se de que seu arquivo CSS principal está importado aqui, ex:
@@ -816,7 +817,7 @@ export default function App() {
                 </Modal.Header>
                 <Modal.Body>
                     <Form>
-                        <FormGroup className="mb-2">
+                        <FormGroup className={styles.spacingSm}>
                             <label>Tarefa *</label>
                             <Input
                                 name="tarefa"
@@ -824,7 +825,7 @@ export default function App() {
                                 onChange={e => setNovaTarefa({ ...novaTarefa, [e.target.name]: e.target.value })}
                             />
                         </FormGroup>
-                        <FormGroup className="mb-2">
+                        <FormGroup className={styles.spacingSm}>
                             <label>Descrição</label>
                             <Input
                                 name="descricao"
@@ -834,7 +835,7 @@ export default function App() {
                         </FormGroup>
                         <Row>
                             <Col>
-                                <FormGroup className="mb-2">
+                                <FormGroup className={styles.spacingSm}>
                                     <label>Responsável *</label>
                                     <Input
                                         as="select"
@@ -848,7 +849,7 @@ export default function App() {
                                 </FormGroup>
                             </Col>
                             <Col>
-                                <FormGroup className="mb-2">
+                                <FormGroup className={styles.spacingSm}>
                                     <label>Repetir *</label>
                                     <Input
                                         as="select"
@@ -864,7 +865,7 @@ export default function App() {
                         </Row>
                         <Row>
                             <Col>
-                                <FormGroup className="mb-2">
+                                <FormGroup className={styles.spacingSm}>
                                     <label>Prioridade *</label>
                                     <Input
                                         as="select"
@@ -879,7 +880,7 @@ export default function App() {
                                 </FormGroup>
                             </Col>
                             <Col>
-                                <FormGroup className="mb-2">
+                                <FormGroup className={styles.spacingSm}>
                                     <label>Setor *</label>
                                     <Input
                                         name="setor"
@@ -931,7 +932,7 @@ export default function App() {
                     <Modal.Title>Editar Observação da Tarefa #{editingObsId}</Modal.Title>
                 </Modal.Header>
                 <Modal.Body>
-                    <FormGroup className="mb-3">
+                    <FormGroup className={styles.spacingMd}>
                         <label>Observações</label>
                         <Input
                             as="textarea"

--- a/src/styles/index.module.css
+++ b/src/styles/index.module.css
@@ -42,3 +42,11 @@
   border: var(--border-width) solid var(--primary);
   font-family: var(--font-family);
 }
+
+.spacingSm {
+  margin-bottom: var(--spacing-sm);
+}
+
+.spacingMd {
+  margin-bottom: var(--spacing-md);
+}


### PR DESCRIPTION
## Summary
- add spacing utilities using CSS variables
- apply theme spacing classes on task and observation overlays

## Testing
- `npm test` *(fails: react-scripts not found)*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/recharts)*

------
https://chatgpt.com/codex/tasks/task_e_68ac92023e58832cbf326e5d45b17d00