### PR TITLE
Carregar observações para tarefas concluídas

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -122,7 +122,7 @@ export default function App() {
                 .from('tarefas')
                 .select(`
                     *,
-                    concluidas!left(data_conclusao, dias_para_conclusao)
+                    concluidas!left(data_conclusao, dias_para_conclusao, observacoes)
                 `)
                 .eq('status', 'CONCLUIDA')
                 .order('id_tarefa');
@@ -136,7 +136,7 @@ export default function App() {
                     data_criacao: formatDate(x.data_criacao),
                     data_criacao_para_ordenacao: x.data_criacao,
                     mes: MESES[new Date(x.data_criacao).getMonth()].substring(0, 3).toUpperCase(),
-                    observacoes: x.em_andamento?.observacoes || '',
+                    observacoes: x.concluidas?.observacoes || x.em_andamento?.observacoes || '',
                     data_conclusao: x.concluidas?.data_conclusao ? formatDate(x.concluidas?.data_conclusao) : '',
                     dias_para_conclusao: x.concluidas?.dias_para_conclusao || 0
                 }));
@@ -144,7 +144,6 @@ export default function App() {
 
             setTarefas(formatar(tarefasData));
             setEmAndamento(formatar(andamentoData));
-            setConcluidas(formatar(concluidasData));
 
             const { data: todasTarefas, error: relatorioError } = await supabase
                 .from('tarefas')
@@ -166,6 +165,9 @@ export default function App() {
                 return acc;
             }, {});
             setRelatorio(agrupados);
+
+            // Recarregar estado de concluidas com observações do banco
+            setConcluidas(formatar(concluidasData));
 
         } catch (e) {
             console.error('Erro ao carregar dados:', e);


### PR DESCRIPTION
## Summary
- Carregue observações das tarefas concluídas ao buscar dados do Supabase
- Recarregue o estado de concluídas para refletir novas observações

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ac9e9ab68c832c94052c2298a54868